### PR TITLE
Add source maps for generated code

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/grunt": "^0.4.21",
     "@types/node": "^7.0.12",
     "@types/sinon": "^2.1.2",
+    "@types/source-map": "^0.5.0",
     "@types/yargs": "^6.6.0",
     "chalk": "^1.1.3",
     "codecov.io": "0.1.6",
@@ -58,6 +59,7 @@
     "@dojo/loader": "beta1",
     "@dojo/routing": "beta1",
     "@dojo/shim": "beta1",
-    "monaco-editor": "^0.8.3"
+    "monaco-editor": "^0.8.3",
+    "source-map": "^0.5.6"
   }
 }

--- a/src/Runner.ts
+++ b/src/Runner.ts
@@ -60,7 +60,7 @@ function docSrc(
 
 	let modulesText = '';
 	for (const mid in modules) {
-		/* inject each source module as it's own <script> block */
+		/* inject each source module as its own <script> block */
 		const filename = mid + '.js';
 		modulesText += '<script>';
 		const source = wrapCode(`cache['${mid}'] = function () {\n`, modules[mid], '\n};\n');

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -6,7 +6,8 @@ interface NodeRequire {
 require.config({
 	paths: {
 		'vs': '../../../node_modules/monaco-editor/min/vs',
-		'@dojo': '../../../node_modules/@dojo'
+		'@dojo': '../../../node_modules/@dojo',
+		'source-map': '../../../node_modules/source-map/dist/source-map.min'
 	},
 	packages: [
 		{ name: 'src', location: '../../..' }

--- a/src/support/base64.ts
+++ b/src/support/base64.ts
@@ -1,0 +1,27 @@
+import global from '@dojo/core/global';
+import has, { add as hasAdd } from '@dojo/has/has';
+
+hasAdd('btoa', 'btoa' in global);
+hasAdd('atob', 'atob' in global);
+
+/**
+ * Take a string encoded in base64 and decode it
+ * @param encodedString The base64 encoded string
+ */
+export const decode: (encodedString: string) => string = has('atob') ? function (encodedString: string) {
+	/* this allows for utf8 characters to be decoded properly */
+	return decodeURIComponent(Array.prototype.map.call(atob(encodedString), (char: string) => '%' + ('00' + char.charCodeAt(0).toString(16)).slice(-2)).join(''));
+} : function (encodedString: string): string {
+	return new Buffer(encodedString.toString(), 'base64').toString('utf8');
+};
+
+/**
+ * Take a string and encode it to base64
+ * @param rawString The string to encode
+ */
+export const encode: (rawString: string) => string = has('btoa') ? function (decodedString: string) {
+	/* this allows for utf8 characters to be encoded properly */
+	return btoa(encodeURIComponent(decodedString).replace(/%([0-9A-F]{2})/g, (match, code: string) => String.fromCharCode(Number('0x' + code))));
+} : function (rawString: string): string {
+	return new Buffer(rawString.toString(), 'utf8').toString('base64');
+};

--- a/src/support/css.ts
+++ b/src/support/css.ts
@@ -98,12 +98,28 @@ export async function getEmit(...files: ProjectFile[]): Promise<EmitFile[]> {
 	for (let i = 0; i < files.length; i++) {
 		const file = files[i];
 		mappedClasses = undefined;
-		const result = await processor.process(file.text);
+		const result = await processor.process(`/* from: ${file.name} */\n\n` + file.text, {
+			from: file.name,
+			map: {
+				sourcesContent: true
+			}
+		});
+
+		/* add emitted css text */
 		emitFiles.push({
 			name: file.name,
 			text: result.css,
 			type: ProjectFileType.CSS
 		});
+
+		/* add source maps */
+		if (result.map) {
+			emitFiles.push({
+				name: file.name + '.map',
+				text: result.map.toString(),
+				type: ProjectFileType.SourceMap
+			});
+		}
 
 		if (mappedClasses) {
 			/* get the basename and strip the extension to be used as the key for the localised CSS */

--- a/src/support/css.ts
+++ b/src/support/css.ts
@@ -112,15 +112,6 @@ export async function getEmit(...files: ProjectFile[]): Promise<EmitFile[]> {
 			type: ProjectFileType.CSS
 		});
 
-		/* add source maps */
-		if (result.map) {
-			emitFiles.push({
-				name: file.name + '.map',
-				text: result.map.toString(),
-				type: ProjectFileType.SourceMap
-			});
-		}
-
 		if (mappedClasses) {
 			/* get the basename and strip the extension to be used as the key for the localised CSS */
 			const key = file.name.split('/').pop()!.replace(/(\.m)?\.css$/, '');

--- a/src/support/sourceMap.ts
+++ b/src/support/sourceMap.ts
@@ -1,0 +1,23 @@
+import { CodeWithSourceMap, SourceMapConsumer, SourceNode } from 'source-map';
+
+const SOURCE_MAP_REGEX = /(?:\/{2}[#@]{1,2}|\/\*)\s+sourceMappingURL\s*=\s*(data:(?:[^;]+;)+base64,)?(\S+)(?:\n\s*)?$/;
+
+/**
+ * Wrap code, which has a source map, with a preamble and a postscript and return the wrapped code with an updated
+ * map.
+ * @param preamble A string to append before the code
+ * @param code The code, with an optional source map in string format
+ * @param postscript A string to append after the code
+ */
+export function wrapCode(preamble: string, code: { map?: string, code: string }, postscript: string): CodeWithSourceMap  {
+	const result = new SourceNode();
+	result.add(preamble);
+	if (code.map) {
+		result.add(SourceNode.fromStringWithSourceMap(code.code.replace(SOURCE_MAP_REGEX, ''), new SourceMapConsumer(code.map)));
+	}
+	else {
+		result.add(code.code);
+	}
+	result.add(postscript);
+	return result.toStringWithSourceMap();
+}

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -38,6 +38,7 @@ export const loaderOptions = {
 		{ name: 'dojo', location: 'node_modules/intern/browser_modules/dojo' },
 		{ name: 'src', location: 'dev/src' },
 		{ name: 'sinon', location: 'node_modules/sinon/pkg', main: 'sinon' },
+		{ name: 'source-map', location: 'node_modules/source-map/dist', main: 'source-map.debug' },
 		{ name: 'tests', location: 'dev/tests' }
 	]
 };

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -12,7 +12,7 @@ export const environments = [
 	{ browserName: 'edge', platform: 'WINDOWS' },
 	{ browserName: 'firefox', platform: 'WINDOWS' },
 	{ browserName: 'chrome', platform: 'WINDOWS' },
-	{ browserName: 'safari', version: '10', platform: 'MAC' },
+	{ browserName: 'safari', version: '9.1', platform: 'MAC' },
 	{ browserName: 'iPad', version: '9.1' }
 ];
 

--- a/tests/unit/Runner.ts
+++ b/tests/unit/Runner.ts
@@ -204,7 +204,7 @@ registerSuite({
 			await runner.run();
 			const doc = getDocFromString(getDocumentStrings(iframe)[0]);
 			const scripts = doc.querySelectorAll('script');
-			assert.lengthOf(scripts, 5, 'should have four script nodes');
+			assert.lengthOf(scripts, 5, 'should have five script nodes');
 			assert.isNotTrue(scripts[0].text, 'script node should not have text');
 			assert.isNotTrue(scripts[1].text, 'script node should not have text');
 			assert.strictEqual(scripts[0].src, 'http://foo.bar/index.js', 'should have proper src attribute');

--- a/tests/unit/Runner.ts
+++ b/tests/unit/Runner.ts
@@ -27,6 +27,17 @@ let projectIndexHtml = '';
 let iframe: HTMLIFrameElement;
 let runner: UnitUnderTest;
 
+const testJS = `define(["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+    function foo() { console.log('bar'); }
+    exports.foo = foo;
+    ;
+});
+`;
+
+const testMap = `{"version":3,"file":"test.js","sourceRoot":"","sources":["test.ts"],"names":[],"mappings":";;;IAAA,iBAAwB,OAAO,CAAC,GAAG,CAAC,KAAK,CAAC,CAAC,CAAC,CAAC;IAA7C,kBAA6C;IAAA,CAAC","sourcesContent":["export function foo() { console.log('bar'); };\\n"]}`;
+
 registerSuite({
 	name: 'Runner',
 
@@ -85,7 +96,7 @@ registerSuite({
 			assert.lengthOf(strings, 1, 'should have the proper number of strings');
 			const doc = getDocFromString(strings[0]);
 			const scripts = doc.querySelectorAll('script');
-			assert.lengthOf(scripts, 2, 'should have had two blocks of script injected');
+			assert.lengthOf(scripts, 3, 'should have had three blocks of script injected');
 			const styles = doc.querySelectorAll('style');
 			assert.lengthOf(styles, 0, 'should have no styles in header');
 		},
@@ -98,14 +109,33 @@ registerSuite({
 		async 'adds modules to run iframe'() {
 			projectEmit.push({
 				name: 'src/foo.js',
-				text: 'define([], function () { console.log("foo"); });',
+				text: testJS,
 				type: ProjectFileType.JavaScript
 			});
 			await runner.run();
 			const doc = getDocFromString(getDocumentStrings(iframe)[0]);
 			const scripts = doc.querySelectorAll('script');
-			assert.include(scripts[1].text, `'src/foo': function`, 'should have exported module');
-			assert.include(scripts[1].text, 'define([], function () { console.log("foo"); });', 'should include module text');
+			assert.include(scripts[2].text, `cache['src/foo'] = function`, 'should have exported module');
+			assert.include(scripts[2].text, testJS, 'should include module text');
+			assert.include(scripts[2].text, '//# sourceURL=src/foo.js', 'should include a source URL');
+		},
+
+		async 'adds modules with source maps to run in iframe'() {
+			projectEmit.push({
+				name: 'src/foo.js',
+				text: testJS,
+				type: ProjectFileType.JavaScript
+			});
+			projectEmit.push({
+				name: 'src/foo.js.map',
+				text: testMap,
+				type: ProjectFileType.SourceMap
+			});
+			await runner.run();
+			const doc = getDocFromString(getDocumentStrings(iframe)[0]);
+			const scripts = doc.querySelectorAll('script');
+			assert.include(scripts[2].text, testJS, 'should include module text');
+			assert.include(scripts[2].text, '//# sourceMappingURL=data:application/json;base64,', 'should include an inline sourcemap');
 		},
 
 		async 'adds css to run iframe'() {
@@ -117,7 +147,6 @@ registerSuite({
 			await runner.run();
 			const doc = getDocFromString(getDocumentStrings(iframe)[0]);
 			const styles = doc.querySelectorAll('style');
-			assert.include(styles[0].textContent!, '/* from: src/main.css */', 'should have comment added');
 			assert.include(styles[0].textContent!, 'body { font-size: 48px }', 'should have text added');
 		},
 
@@ -143,7 +172,6 @@ registerSuite({
 			await runner.run();
 			const doc = getDocFromString(getDocumentStrings(iframe)[0]);
 			const styles = doc.querySelectorAll('style');
-			assert.include(styles[0].textContent!, '/* from: project index */', 'should have comment added');
 			assert.include(styles[0].textContent!, 'body { font-size: 12px; }', 'should have text added');
 			assert.include(styles[0].textContent!, '.foo { font-size: 24px; }', 'should have text added');
 			assert.include(styles[0].textContent!, '.bar { font-size: 72px; }', 'should have text added');
@@ -176,7 +204,7 @@ registerSuite({
 			await runner.run();
 			const doc = getDocFromString(getDocumentStrings(iframe)[0]);
 			const scripts = doc.querySelectorAll('script');
-			assert.lengthOf(scripts, 4, 'should have four script nodes');
+			assert.lengthOf(scripts, 5, 'should have four script nodes');
 			assert.isNotTrue(scripts[0].text, 'script node should not have text');
 			assert.isNotTrue(scripts[1].text, 'script node should not have text');
 			assert.strictEqual(scripts[0].src, 'http://foo.bar/index.js', 'should have proper src attribute');
@@ -240,7 +268,7 @@ registerSuite({
 				});
 				const doc = getDocFromString(text);
 				const scripts = doc.querySelectorAll('script');
-				assert.lengthOf(scripts, 2, 'should have two script blocks');
+				assert.lengthOf(scripts, 3, 'should have three script blocks');
 				assert.strictEqual(scripts[0].getAttribute('src'), 'foo.bar.js\n', 'should set proper loader source');
 			},
 

--- a/tests/unit/support/all.ts
+++ b/tests/unit/support/all.ts
@@ -1,3 +1,4 @@
+import './base64';
 import './css';
 import './DOMParser';
 import './gists';
@@ -5,4 +6,5 @@ import './json';
 import './postcss';
 import './postcssCssnext';
 import './postcssModules';
+import './sourceMap';
 import './providers/all';

--- a/tests/unit/support/base64.ts
+++ b/tests/unit/support/base64.ts
@@ -1,0 +1,27 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import * as base64 from '../../../src/support/base64';
+
+registerSuite({
+	name: 'support/base64',
+
+	'encode()': {
+		'normal string'() {
+			assert.strictEqual(base64.encode('foo bar baz'), 'Zm9vIGJhciBiYXo=', 'should have encoded properly');
+		},
+
+		'utf8 string'() {
+			assert.strictEqual(base64.encode('💩😱🦄'), '8J+SqfCfmLHwn6aE', 'should have encoded properly');
+		}
+	},
+
+	'decode()': {
+		'normal string'() {
+			assert.strictEqual(base64.decode('Zm9vIGJhciBiYXo='), 'foo bar baz', 'should have decoded properly');
+		},
+
+		'utf8 string'() {
+			assert.strictEqual(base64.decode('8J+SqfCfmLHwn6aE'), '💩😱🦄', 'should have decoded properly');
+		}
+	}
+});

--- a/tests/unit/support/sourceMap.ts
+++ b/tests/unit/support/sourceMap.ts
@@ -1,0 +1,61 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { wrapCode } from '../../../src/support/sourceMap';
+import * as sourceMap from 'source-map';
+
+const SOURCE_MAP_REGEX = /(?:\/{2}[#@]{1,2}|\/\*)\s+sourceMappingURL\s*=\s*(data:(?:[^;]+;)+base64,)?(\S+)(?:\n\s*)?$/;
+
+const code = `(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports", "./Editor", "./project", "./Runner"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    var Editor_1 = require("./Editor");
+    var project_1 = require("./project");
+    var Runner_1 = require("./Runner");
+    return {
+        Editor: Editor_1.default,
+        project: project_1.default,
+        Runner: Runner_1.default
+    };
+});
+//# sourceMappingURL=main.js.map`;
+
+const map = `{"version":3,"file":"main.js","sourceRoot":"","sources":["../../src/main.ts"],"names":[],"mappings":";;;;;;;;;;IAAA,mCAA8B;IAC9B,qCAAgC;IAChC,mCAA8B;IAE9B,OAAS;QACR,MAAM,kBAAA;QACN,OAAO,mBAAA;QACP,MAAM,kBAAA;KACN,CAAC","sourcesContent":["import Editor from './Editor';\\nimport project from './project';\\nimport Runner from './Runner';\\n\\nexport = {\\n\\tEditor,\\n\\tproject,\\n\\tRunner\\n};\\n"]}`;
+
+const smc = new sourceMap.SourceMapConsumer(map);
+
+registerSuite({
+	name: 'support/sourceMap',
+
+	'wrapCode()': {
+		'module with sourcemap'() {
+			const originalPosition = smc.originalPositionFor({
+				line: 14,
+				column: 5
+			});
+			const actual = wrapCode(`/* a\nmulti-line\ncomment */\n`, {
+				code,
+				map
+			}, `/* some\nsort of\ncomment postscript */`);
+			const actualSmc = new sourceMap.SourceMapConsumer(actual.map.toJSON());
+			assert.deepEqual(actualSmc.originalPositionFor({
+				line: 17,
+				column: 5
+			}), originalPosition, 'actual sourcemap should have added expected lines');
+			assert.isFalse(SOURCE_MAP_REGEX.test(actual.code), 'code should not have any sourceMappingURL');
+		},
+
+		'code without a sourcemap'() {
+			const actual = wrapCode(`/* a\nmulti-line\ncomment */\n`, {
+				code
+			}, `/* some\nsort of\ncomment postscript */`);
+			assert.deepEqual(actual.map.toJSON(), { version: 3, sources: [], names: [], mappings: '' }, 'should return an empty source map');
+		}
+	}
+});


### PR DESCRIPTION
**Feature**

This PR provides support for source maps in generated code.  It also "names" the scripts in a way that is recognised by some debuggers that make debugging dynamically generated applications from the Runner easier to debug.  In Chrome DevTools, breakpoints can be set on the generated runner applications.

This also includes source maps for CSS as well, which Chrome DevTools will automatically recognise.

The dynamically generated JavaScript will be located under the runner `iframe`:

<img width="272" alt="_dojo_web-editor" src="https://cloud.githubusercontent.com/assets/1282577/25744310/1c39b0f8-3191-11e7-8c02-c17fc14f939e.png">

For some reason the original TypeScript is not visible at this point, but if you wanted to set a breakpoint on the generated code, you would open the emitted JavaScript:

<img width="686" alt="_dojo_web-editor" src="https://cloud.githubusercontent.com/assets/1282577/25744358/734844d6-3191-11e7-880b-4451f6c95099.png">

And when you click on the gutter to set the breakpoint, Chrome will realise it has a source map and open up the original TypeScript file:

<img width="524" alt="_dojo_web-editor" src="https://cloud.githubusercontent.com/assets/1282577/25744402/a9a3e328-3191-11e7-88c4-f6a544c5cb2c.png">

After this point, debugging the application should work, remembering the breakpoints.
